### PR TITLE
Verify and fix nx build system

### DIFF
--- a/libs/components/src/styles/main.css
+++ b/libs/components/src/styles/main.css
@@ -1,0 +1,35 @@
+/* LiqUIdify Main CSS Entry Point */
+/* Import all glass styles */
+@import './glass.css';
+@import './optimized-glass-effects.css';
+@import './apple-liquid-authentic.css';
+@import './glass-core.css';
+@import './glass-utilities.css';
+@import './glass-animations.css';
+@import './glass-themes.css';
+@import './graceful-degradation.css';
+
+/* Base Glass UI Styles */
+.glass-ui {
+  --glass-bg: rgba(255, 255, 255, 0.1);
+  --glass-border: rgba(255, 255, 255, 0.2);
+  --glass-text: rgba(0, 0, 0, 0.8);
+  --glass-blur: 10px;
+  --glass-saturation: 180%;
+}
+
+[data-theme='dark'] .glass-ui {
+  --glass-bg: rgba(0, 0, 0, 0.1);
+  --glass-border: rgba(255, 255, 255, 0.2);
+  --glass-text: rgba(255, 255, 255, 0.9);
+}
+
+/* Storybook compatibility */
+body {
+  background: var(--glass-bg-canvas, #ffffff);
+  transition: background-color 0.3s ease;
+}
+
+[data-theme='dark'] body {
+  background: var(--glass-bg-dark-canvas, #0a0a0a);
+}

--- a/libs/components/src/styles/tailwind.css
+++ b/libs/components/src/styles/tailwind.css
@@ -1,4 +1,7 @@
-@import 'tailwindcss';
+/* Tailwind CSS Base Styles */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
 
 /* Import LiqUIdify Glass Styles */
 @import './glass.css';

--- a/scripts/build-css-lightning.ts
+++ b/scripts/build-css-lightning.ts
@@ -2,7 +2,7 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { type BundleOptions, bundle } from 'lightningcss';
 
-const inputFile = join(process.cwd(), 'src/styles/tailwind.css');
+const inputFile = join(process.cwd(), 'libs/components/src/styles/main.css');
 const outputFile = join(process.cwd(), 'dist/liquidui.css');
 
 // Ensure output directory exists


### PR DESCRIPTION
<!-- Fixes CSS build failures by updating the Lightning CSS input path and restructuring CSS imports for proper resolution. -->

The CSS build was failing because the Lightning CSS script was configured with an incorrect input path and could not resolve the `@import 'tailwindcss';` directive. This PR introduces a new `main.css` entry point in `libs/components/src/styles/` and updates the build script to use it. Additionally, `tailwind.css` was updated to use `@tailwind` directives, resolving the import issue with Lightning CSS.

---

[Open in Web](https://cursor.com/agents?id=bc-a8724b52-1a97-4c29-8f54-59335d2327db) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-a8724b52-1a97-4c29-8f54-59335d2327db) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed CSS build failures by adding a main.css entry point and updating the build script to use it. Updated Tailwind CSS imports to use @tailwind directives for better compatibility with Lightning CSS.

- **Bug Fixes**
  - Corrected Lightning CSS input path to resolve all imports.
  - Replaced @import 'tailwindcss' with @tailwind directives in tailwind.css.

<!-- End of auto-generated description by cubic. -->

