### PR TITLE
Fix Nx build configuration issues

### DIFF
--- a/libs/components/project.json
+++ b/libs/components/project.json
@@ -49,7 +49,8 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "bun biome lint libs/components/src/**/*.{ts,tsx}"
+        "command": "biome lint --no-errors-on-unmatched libs/components/src",
+        "cwd": "{workspaceRoot}"
       },
       "cache": true
     },

--- a/libs/components/vite.config.ts
+++ b/libs/components/vite.config.ts
@@ -11,11 +11,10 @@ export default defineConfig({
   plugins: [
     react(),
     nxViteTsPaths(),
-    // dts({
-    //   entryRoot: "src",
-    //   tsConfigFilePath: path.join(__dirname, "tsconfig.lib.json"),
-    //   skipDiagnostics: true,
-    // }),
+    dts({
+      entryRoot: "src",
+      tsconfigPath: path.join(__dirname, "tsconfig.lib.json"),
+    }),
   ],
   resolve: {
     alias: {

--- a/scripts/build-css-lightning.ts
+++ b/scripts/build-css-lightning.ts
@@ -2,8 +2,8 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { type BundleOptions, bundle } from 'lightningcss';
 
-const inputFile = join(process.cwd(), 'libs/components/src/styles/glass.css');
-const outputFile = join(process.cwd(), 'dist/liquidui.css');
+const inputFile = join(__dirname, '../libs/components/src/styles/glass.css');
+const outputFile = join(__dirname, '../dist/liquidui.css');
 
 // Ensure output directory exists
 mkdirSync(dirname(outputFile), { recursive: true });

--- a/scripts/build-css-lightning.ts
+++ b/scripts/build-css-lightning.ts
@@ -2,13 +2,13 @@ import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { type BundleOptions, bundle } from 'lightningcss';
 
-const inputFile = join(process.cwd(), 'src/styles/tailwind.css');
+const inputFile = join(process.cwd(), 'libs/components/src/styles/glass.css');
 const outputFile = join(process.cwd(), 'dist/liquidui.css');
 
 // Ensure output directory exists
 mkdirSync(dirname(outputFile), { recursive: true });
 
-const options: BundleOptions<void> = {
+const options: BundleOptions<any> = {
   filename: inputFile,
   minify: process.env.NODE_ENV === 'production',
   sourceMap: true,

--- a/scripts/build-css-lightning.ts
+++ b/scripts/build-css-lightning.ts
@@ -8,7 +8,7 @@ const outputFile = join(__dirname, '../dist/liquidui.css');
 // Ensure output directory exists
 mkdirSync(dirname(outputFile), { recursive: true });
 
-const options: BundleOptions<{ [key: string]: number }> = {
+const options: BundleOptions<{}> = {
   filename: inputFile,
   minify: process.env.NODE_ENV === 'production',
   sourceMap: true,


### PR DESCRIPTION
# Fix Nx build configuration issues

## Summary

This PR resolves critical Nx build configuration issues that were preventing TypeScript declaration generation and causing lint commands to hang. The main fixes include:

- **Enabled TypeScript declaration generation** by uncommenting and properly configuring the `vite-plugin-dts` in the Vite config
- **Fixed CSS build script** to use the correct input file path and resolve TypeScript errors
- **Updated lint command configuration** to prevent hanging with `--no-errors-on-unmatched` flag

The build now successfully generates 237+ TypeScript declaration files and completes without errors, while the CSS build properly processes the glass styles.

## Review & Testing Checklist for Human

- [ ] **Verify CSS styling works correctly** - The CSS build input was changed from `tailwind.css` to `glass.css`. Test that all glassmorphism styles render properly in Storybook and applications
- [ ] **Test TypeScript declarations for package consumers** - Verify that the generated `.d.ts` files work correctly when importing components from the package, especially for the export paths defined in `package.json`
- [ ] **Confirm lint commands don't hang** - Test `bun run lint` and individual lint commands to ensure they complete without infinite retry loops
- [ ] **Validate build output structure** - Check that the generated files in `dist/libs/components/` match the expected package.json exports and can be properly consumed by applications

**Recommended test plan:**
1. Run `bun run build` and verify it completes successfully
2. Import a component from the built package in a test application
3. Run lint commands and confirm they finish execution
4. Test visual styling in Storybook to ensure CSS is properly bundled

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
graph TD
    vite_config["libs/components/<br/>vite.config.ts"]:::major-edit
    project_json["libs/components/<br/>project.json"]:::minor-edit
    css_script["scripts/<br/>build-css-lightning.ts"]:::major-edit
    
    package_json["package.json"]:::context
    glass_css["libs/components/src/<br/>styles/glass.css"]:::context
    dist_output["dist/libs/<br/>components/*.d.ts"]:::context
    
    vite_config -->|"enables DTS plugin"| dist_output
    css_script -->|"reads from"| glass_css
    project_json -->|"runs lint with<br/>new flags"| css_script
    package_json -->|"exports reference"| dist_output
    
    subgraph Legend
        L1["Major Edit"]:::major-edit
        L2["Minor Edit"]:::minor-edit  
        L3["Context/No Edit"]:::context
    end

    classDef major-edit fill:#90EE90
    classDef minor-edit fill:#87CEEB
    classDef context fill:#FFFFFF
```

### Notes

- The build was previously failing due to commented-out DTS plugin and incorrect CSS file paths
- TypeScript declarations are now properly generated (237 files found in dist/)
- Some TypeScript strict mode errors remain in the codebase but are unrelated to the Nx configuration fixes
- The lint hanging issue was partially resolved but may need further investigation for edge cases

**Session details:**
- Requested by: Tulio Cunha (@tuliopc23)
- Session URL: https://app.devin.ai/sessions/8eec2ffd99e54ee388dcf478fd8b4759
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed Nx build issues by enabling TypeScript declaration generation, correcting the CSS build script path, and updating the lint command to prevent hanging.

- **Build Fixes**
  - Enabled DTS plugin in Vite config for TypeScript declarations.
  - Updated CSS build script to use the correct glass.css input file.
  - Changed lint command to avoid hanging with the --no-errors-on-unmatched flag.

<!-- End of auto-generated description by cubic. -->

