### PR TITLE
fix: resolve ES module __dirname issue and update vercel.json configuration

### DIFF
--- a/scripts/build-css-lightning.ts
+++ b/scripts/build-css-lightning.ts
@@ -1,6 +1,9 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { type BundleOptions, bundle } from 'lightningcss';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
 
 const inputFile = join(__dirname, '../libs/components/src/styles/glass.css');
 const outputFile = join(__dirname, '../dist/liquidui.css');

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "bun install --frozen-lockfile",
   "buildCommand": "bun run build-storybook",
   "outputDirectory": "dist/storybook",
-  "installCommand": "bun install",
-  "framework": null
+  "framework": "vite"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -3,5 +3,5 @@
   "installCommand": "bun install --frozen-lockfile",
   "buildCommand": "bun run build-storybook",
   "outputDirectory": "dist/storybook",
-  "framework": "vite"
+  "framework": null
 }


### PR DESCRIPTION
# Fix: Resolve ES module __dirname issue and update vercel.json configuration

## Summary

This PR fixes the Nx + Vercel deployment failures by resolving a critical ES module compatibility issue in the CSS build script and updating the Vercel configuration with recommended best practices.

**Root Cause:** The `scripts/build-css-lightning.ts` file was using `__dirname` which is not available in ES module scope, causing the CSS build step to fail during Storybook builds.

**Changes Made:**
1. **Fixed ES module __dirname issue** - Updated `build-css-lightning.ts` to use `fileURLToPath(new URL('.', import.meta.url))` pattern (following existing pattern from `vite.config.ts`)
2. **Enhanced Vercel configuration** - Updated `vercel.json` with schema validation, frozen lockfile installation, and proper framework specification

## Review & Testing Checklist for Human

- [ ] **Deploy to Vercel and verify deployment succeeds** - The most critical test since this was the original failure point
- [ ] **Verify CSS build outputs correctly** - Check that `dist/liquidui.css` is generated properly and contains expected styles
- [ ] **Test Storybook build completeness** - Ensure `dist/storybook` contains all necessary files and loads correctly

---

### Diagram

```mermaid
%%{ init : { "theme" : "default" }}%%
flowchart TD
    vercel["vercel.json"]:::major-edit
    buildScript["scripts/build-css-lightning.ts"]:::major-edit
    storybook["apps/storybook/project.json"]:::context
    cssFile["libs/components/src/styles/glass.css"]:::context
    distCSS["dist/liquidui.css"]:::context
    distStorybook["dist/storybook/"]:::context
    
    vercel --> |"configures deployment"| distStorybook
    buildScript --> |"generates"| distCSS
    cssFile --> |"input"| buildScript
    storybook --> |"depends on"| buildScript
    storybook --> |"builds to"| distStorybook
    
    subgraph Legend
        L1[Major Edit]:::major-edit
        L2[Minor Edit]:::minor-edit  
        L3[Context/No Edit]:::context
    end

classDef major-edit fill:#90EE90
classDef minor-edit fill:#87CEEB  
classDef context fill:#FFFFFF
```

### Notes

**Confidence Level:** Medium 🟡 - The fix follows established patterns in the codebase and local testing confirms the build works, but Vercel deployment behavior can only be verified in production.

**Testing Performed:** 
- ✅ CSS build (`bun run build:css`) completes successfully
- ✅ Full Storybook build (`bun run build-storybook`) completes and outputs to `dist/storybook`
- ❌ Actual Vercel deployment not tested (requires production environment)

**Session Info:**
- Link to Devin run: https://app.devin.ai/sessions/2e4b21f920b14ea5ac68b1d5316508da
- Requested by: @tuliopc23

The ES module fix was implemented using the same pattern already established in `vite.config.ts`, making it consistent with the existing codebase architecture.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed ES module compatibility in the CSS build script and updated vercel.json to improve deployment reliability.

- **Bug Fixes**
  - Replaced __dirname usage in build-css-lightning.ts with fileURLToPath for ES module support.
  - Updated vercel.json with schema validation, frozen lockfile install, and framework set to vite.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved reliability of the CSS build process by explicitly defining file path resolution.
  * Updated deployment configuration to enforce lockfile consistency and include schema validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->